### PR TITLE
Added a thin wrapper to check for a bug in boost causing problems.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,6 +81,7 @@ add_library(${PROJECT_NAME}
     include/${PROJECT_NAME}/get_neighbours.hpp
     include/${PROJECT_NAME}/serialization.hpp
     include/${PROJECT_NAME}/serialization_ros.hpp
+    include/${PROJECT_NAME}/filesystem.hpp
     src/${PROJECT_NAME}/zlib_helpers.cpp
     src/${PROJECT_NAME}/base64_helpers.cpp
     src/${PROJECT_NAME}/first_order_deformation.cpp)

--- a/include/arc_utilities/filesystem.hpp
+++ b/include/arc_utilities/filesystem.hpp
@@ -1,0 +1,35 @@
+#ifndef FILESYSTEM_HPP
+#define FILESYSTEM_HPP
+
+#include <iostream>
+#include <boost/filesystem.hpp>
+#include "arc_utilities/arc_exceptions.hpp"
+
+namespace arc_utilities
+{
+    void CreateDirectory(const boost::filesystem::path& p)
+    {
+        if (!boost::filesystem::is_directory(p))
+        {
+            std::cout << "\x1b[33;1m" << p << " does not exist! Creating ... ";
+
+            // NOTE: create_directories should be able to return true in this case
+            // however due to a bug related to a trailing '/' this is not currently
+            // the case in my version of boost
+            // https://svn.boost.org/trac/boost/ticket/7258
+            boost::filesystem::create_directories(p);
+            if (boost::filesystem::is_directory(p))
+    //            if (boost::filesystem::create_directories(p))
+            {
+                std::cout << "Succeeded!\x1b[37m\n";
+            }
+            else
+            {
+                std::cout << "\x1b[31;1mFailed!\x1b[37m\n";
+                throw_arc_exception(std::runtime_error, "Unable to create directory, likely a 'trailing slash' issue");
+            }
+        }
+    }
+}
+
+#endif // FILESYSTEM_HPP


### PR DESCRIPTION
I don't see any particular reason not to merge this, but perhaps change the function name to "EnsureDirectoryExists" or something. Or perhaps change the name to match the boost name?