### PR TITLE
Xbox conversion

### DIFF
--- a/src/arc_utilities/ros_helpers.py
+++ b/src/arc_utilities/ros_helpers.py
@@ -35,4 +35,25 @@ class Listener:
         """
         with self.lock:
             return self.data
+
+
+def joy_to_xbox(joy):
+    """
+    Transforms a joystick sensor_msg to a XBox controller for easier code readability
+    
+    Parameters:
+    joy (sensor_msgs/Joy): xbox msg
+
+    Returns:
+    xbox struct where fields are the button names
+    """
+    x = object
+    x.A, x.B, x.X, x.Y, x.LB, x.RB, \
+        x.back, x.start, x.power,\
+        x.stick_button_left, x.stick_button_right, \
+        x.DL, x.DR, x.DU, x.DD = joy.buttons
+    x.LH, x.LV, x.LT, x.RH, x.RV, x.RT, x.DH, x.DV = joy.axes
+    return x
+        
+
     

--- a/src/arc_utilities/ros_helpers.py
+++ b/src/arc_utilities/ros_helpers.py
@@ -17,7 +17,6 @@ class Listener:
         Parameters:
             topic_name (str): name of topic to subscribe to
             topic_type (msg_type): type of message received on topic
-            lock (Lock): optional lock object used when setting stored data
         """
 
         self.data = None


### PR DESCRIPTION
Listener now has a "block_on_none" parameter. Perhaps this should be default "True"?

Also change the blocking methods so they exit cleanly on ctrl-C out of ROS


Interfacing with the xbox controller is now super easy.

from ros_helpers import *
xbox = Xbox()
xbox.wait_for_button("A")


