### PR TITLE
Edge validity

### DIFF
--- a/include/arc_utilities/dijkstras.hpp
+++ b/include/arc_utilities/dijkstras.hpp
@@ -302,7 +302,7 @@ namespace arc_dijkstras
             distance_ = distance;
         }
 
-        GraphEdge& GetEdgeMutable(int64_t other_node_ind)
+        GraphEdge& GetEdgeMutable(const int64_t other_node_ind)
         {
             for(auto &e: out_edges_)
             {
@@ -311,7 +311,7 @@ namespace arc_dijkstras
                     return e;
                 }
             }
-            throw std::invalid_argument("invalid node index, no edge exists");
+            throw std::invalid_argument("Invalid node index, no edge exists");
         }
 
         const std::vector<GraphEdge>& GetInEdgesImmutable() const
@@ -633,19 +633,6 @@ namespace arc_dijkstras
         std::pair<const GraphEdge, const GraphEdge>
         AddEdgesBetweenNodes(const int64_t first_index, const int64_t second_index, const double edge_weight)
         {
-            // We retrieve the nodes first, since retrieval performs bounds checks first
-            // GraphNode<NodeValueType, Allocator>& first_node = GetNodeMutable(first_index);
-            // GraphNode<NodeValueType, Allocator>& second_node = GetNodeMutable(second_index);
-            // if (first_index == second_index)
-            // {
-            //     throw std::invalid_argument("Invalid circular edge first==second not allowed");
-            // }
-            // const GraphEdge first_edge(first_index, second_index, edge_weight);
-            // first_node.AddOutEdge(first_edge);
-            // second_node.AddInEdge(first_edge);
-            // const GraphEdge second_edge(second_index, first_index, edge_weight);
-            // second_node.AddOutEdge(second_edge);
-            // first_node.AddInEdge(second_edge);
             GraphEdge& e1 = AddEdgeBetweenNodes(first_index, second_index, edge_weight);
             GraphEdge& e2 = AddEdgeBetweenNodes(second_index, first_index, edge_weight);
             return std::make_pair(e1, e2);
@@ -984,10 +971,6 @@ namespace arc_dijkstras
             };
             return PerformLazyAstar(graph, start_index, goal_index, edge_validity_check_function, distance_function, heuristic_fn, limit_pqueue_duplicates);
         }
-
-
-
-
     };
 
     template<typename NodeValueType, typename Allocator = std::allocator<NodeValueType>>

--- a/include/arc_utilities/dijkstras.hpp
+++ b/include/arc_utilities/dijkstras.hpp
@@ -78,6 +78,10 @@ namespace arc_dijkstras
             const std::pair<double, uint64_t> deserialized_weight = arc_utilities::DeserializeFixedSizePOD<double>(buffer, current_position);
             weight_ = deserialized_weight.first;
             current_position += deserialized_weight.second;
+            const std::pair<EDGE_VALIDITY, uint64_t> deserialized_validity = arc_utilities::DeserializeFixedSizePOD<EDGE_VALIDITY>(buffer, current_position);
+            edge_validity_ = deserialized_validity.first;
+            current_position += deserialized_validity.second;
+            
             // Figure out how many bytes were read
             const uint64_t bytes_read = current_position - current;
             return bytes_read;
@@ -420,8 +424,8 @@ namespace arc_dijkstras
 
 
         uint64_t SerializeSelf(
-                std::vector<uint8_t>& buffer,
-                const std::function<uint64_t(const NodeValueType&, std::vector<uint8_t>&)>& value_serializer) const
+            std::vector<uint8_t>& buffer,
+            const std::function<uint64_t(const NodeValueType&, std::vector<uint8_t>&)>& value_serializer) const
         {
             const uint64_t start_buffer_size = buffer.size();
             const auto graph_state_serializer = std::bind(GraphNode<NodeValueType, Allocator>::Serialize, std::placeholders::_1, std::placeholders::_2, value_serializer);
@@ -433,9 +437,9 @@ namespace arc_dijkstras
         }
 
         uint64_t DeserializeSelf(
-                const std::vector<uint8_t>& buffer,
-                const uint64_t current,
-                const std::function<std::pair<NodeValueType, uint64_t>(const std::vector<uint8_t>&, const uint64_t)>& value_deserializer)
+            const std::vector<uint8_t>& buffer,
+            const uint64_t current,
+            const std::function<std::pair<NodeValueType, uint64_t>(const std::vector<uint8_t>&, const uint64_t)>& value_deserializer)
         {
             const auto graph_state_deserializer = std::bind(GraphNode<NodeValueType, Allocator>::Deserialize, std::placeholders::_1, std::placeholders::_2, value_deserializer);
             const auto deserialized_nodes = arc_utilities::DeserializeVector<GraphNode<NodeValueType, Allocator>>(buffer, current, graph_state_deserializer);

--- a/include/arc_utilities/serialization.hpp
+++ b/include/arc_utilities/serialization.hpp
@@ -19,6 +19,12 @@ namespace arc_utilities
             const T& item_to_serialize,
             std::vector<uint8_t>& buffer);
 
+    /**
+     *  @brief DeserializeFixedSizePOD
+     *  @param buffer: vector of data
+     *  @param current: next index to read
+     *  @return std::pair<deserialized value, bytes read>
+     **/
     template<typename T>
     inline std::pair<T, uint64_t> DeserializeFixedSizePOD(
             const std::vector<uint8_t>& buffer,


### PR DESCRIPTION
@dmcconachie I think we are the only people that use this.

This adds an explicit "edge validity" parameter to each edge. 
This adds a byte to GraphEdge, and therefore changes serialization, so old saved graphs will be broken

Note: Validity could be implicitly accomplished, using -1 for unknown, and inf for invalid or something