### PR TITLE
std::pair<> and RGBA color math

### DIFF
--- a/include/arc_utilities/arc_helpers.hpp
+++ b/include/arc_utilities/arc_helpers.hpp
@@ -588,6 +588,10 @@ namespace arc_helpers
         }
     }
 
+    /**
+     * @brief Multiply Multiples the color channels (r, g, b) of @color by
+     *        @factor, ensuring the result stays in the range [0, 1]
+     */
     template<typename ColorType>
     inline ColorType Multiply(const ColorType& color, const float factor)
     {
@@ -595,18 +599,7 @@ namespace arc_helpers
         ret.r = TrimColorValue(factor * color.r);
         ret.g = TrimColorValue(factor * color.g);
         ret.b = TrimColorValue(factor * color.b);
-        ret.a = TrimColorValue(factor * color.a);
-        return ret;
-    }
-
-    template<typename ColorType>
-    inline ColorType Add(const ColorType& c1, const ColorType& c2)
-    {
-        ColorType ret;
-        ret.r = TrimColorValue(c1.r + c2.r);
-        ret.g = TrimColorValue(c1.g + c2.g);
-        ret.b = TrimColorValue(c1.b + c2.b);
-        ret.a = TrimColorValue(c1.a + c2.a);
+        ret.a = color.a;
         return ret;
     }
 
@@ -634,7 +627,12 @@ namespace arc_helpers
         }
         // Interpolate
         // This is the numerically stable version, rather than  (c1 + (c2 - c1) * real_ratio)
-        return Add(Multiply(c1, 1.0 - real_ratio), Multiply(c2, real_ratio));
+        ColorType ret;
+        ret.r = TrimColorValue(c1.r * (1.0 - real_ratio) + c2.r * real_ratio);
+        ret.g = TrimColorValue(c1.g * (1.0 - real_ratio) + c2.g * real_ratio);
+        ret.b = TrimColorValue(c1.b * (1.0 - real_ratio) + c2.b * real_ratio);
+        ret.a = TrimColorValue(c1.a * (1.0 - real_ratio) + c2.a * real_ratio);
+        return ret;
     }
 
     ////////////////////////////////////////////////////////////////////////////

--- a/include/arc_utilities/arc_helpers.hpp
+++ b/include/arc_utilities/arc_helpers.hpp
@@ -616,6 +616,13 @@ namespace arc_helpers
         return ret;
     }
 
+    /**
+     * @brief InterpolateColor
+     * @param c1 Start color for interpolation
+     * @param c2 End color for interpolation
+     * @param ratio Value between 0 and 1, indicating how far to move from c1 towards c2
+     * @return
+     */
     template<typename ColorType>
     inline ColorType InterpolateColor(const ColorType& c1, const ColorType& c2, const float& ratio)
     {

--- a/include/arc_utilities/arc_helpers.hpp
+++ b/include/arc_utilities/arc_helpers.hpp
@@ -610,9 +610,9 @@ namespace arc_helpers
     {
         ColorType ret;
         ret.r = TrimColorValue(c1.r + c2.r);
-        ret.r = TrimColorValue(c1.g + c2.b);
-        ret.r = TrimColorValue(c1.b + c2.g);
-        ret.r = TrimColorValue(c1.a + c2.a);
+        ret.g = TrimColorValue(c1.g + c2.g);
+        ret.b = TrimColorValue(c1.b + c2.b);
+        ret.a = TrimColorValue(c1.a + c2.a);
         return ret;
     }
 

--- a/include/arc_utilities/arc_helpers.hpp
+++ b/include/arc_utilities/arc_helpers.hpp
@@ -600,12 +600,6 @@ namespace arc_helpers
     }
 
     template<typename ColorType>
-    inline ColorType Multiply(const float factor, const ColorType& color)
-    {
-        return color * factor;
-    }
-
-    template<typename ColorType>
     inline ColorType Add(const ColorType& c1, const ColorType& c2)
     {
         ColorType ret;

--- a/include/arc_utilities/arc_helpers.hpp
+++ b/include/arc_utilities/arc_helpers.hpp
@@ -604,7 +604,9 @@ namespace arc_helpers
     }
 
     /**
-     * @brief InterpolateColor
+     * @brief InterpolateColor Interpolates between c1 and c2 directly in RGBA space.
+     *  @ColorType is intended to be a ros std_msgs::ColorRGBA type, or the RGBAColor
+     *  defined in this file
      * @param c1 Start color for interpolation
      * @param c2 End color for interpolation
      * @param ratio Value between 0 and 1, indicating how far to move from c1 towards c2

--- a/include/arc_utilities/arc_helpers.hpp
+++ b/include/arc_utilities/arc_helpers.hpp
@@ -296,6 +296,8 @@ namespace arc_helpers
         return val;
     }
 
+    //// Color Related Functionality ///////////////////////////////////////////
+
     inline constexpr float ColorChannelFromHex(uint8_t hexval)
     {
         return (float)hexval / 255.0f;
@@ -585,6 +587,56 @@ namespace arc_helpers
             return RGBAColorBuilder<ColorType>::MakeFromFloatColors(0.0f, 0.0f, 0.0f, alpha);
         }
     }
+
+    template<typename ColorType>
+    inline ColorType Multiply(const ColorType& color, const float factor)
+    {
+        ColorType ret;
+        ret.r = TrimColorValue(factor * color.r);
+        ret.g = TrimColorValue(factor * color.g);
+        ret.b = TrimColorValue(factor * color.b);
+        ret.a = TrimColorValue(factor * color.a);
+        return ret;
+    }
+
+    template<typename ColorType>
+    inline ColorType Multiply(const float factor, const ColorType& color)
+    {
+        return color * factor;
+    }
+
+    template<typename ColorType>
+    inline ColorType Add(const ColorType& c1, const ColorType& c2)
+    {
+        ColorType ret;
+        ret.r = TrimColorValue(c1.r + c2.r);
+        ret.r = TrimColorValue(c1.g + c2.b);
+        ret.r = TrimColorValue(c1.b + c2.g);
+        ret.r = TrimColorValue(c1.a + c2.a);
+        return ret;
+    }
+
+    template<typename ColorType>
+    inline ColorType InterpolateColor(const ColorType& c1, const ColorType& c2, const float& ratio)
+    {
+        // Safety check ratio
+        float real_ratio = ratio;
+        if (real_ratio < 0.0)
+        {
+            real_ratio = 0.0;
+            std::cerr << "Interpolation ratio < 0.0, set to 0.0" << std::endl;
+        }
+        else if (real_ratio > 1.0)
+        {
+            real_ratio = 1.0;
+            std::cerr << "Interpolation ratio > 1.0, set to 1.0" << std::endl;
+        }
+        // Interpolate
+        // This is the numerically stable version, rather than  (c1 + (c2 - c1) * real_ratio)
+        return Add(Multiply(c1, 1.0 - real_ratio), Multiply(c2, real_ratio));
+    }
+
+    ////////////////////////////////////////////////////////////////////////////
 
     inline size_t GetNumOMPThreads()
     {

--- a/include/arc_utilities/eigen_helpers.hpp
+++ b/include/arc_utilities/eigen_helpers.hpp
@@ -398,11 +398,10 @@ namespace EigenHelpers
     // Interpolation functions
     ////////////////////////////////////////////////////////////////////////////
 
-    template<typename T1, typename T2>
-    inline double Interpolate(const T1& p1, const T1& p2, const T2& ratio)
+    inline double Interpolate(const double p1, const double p2, const double ratio)
     {
         // Safety check ratio
-        T2 real_ratio = ratio;
+        double real_ratio = ratio;
         if (real_ratio < 0.0)
         {
             real_ratio = 0.0;

--- a/include/arc_utilities/eigen_helpers.hpp
+++ b/include/arc_utilities/eigen_helpers.hpp
@@ -398,10 +398,11 @@ namespace EigenHelpers
     // Interpolation functions
     ////////////////////////////////////////////////////////////////////////////
 
-    inline double Interpolate(const double p1, const double p2, const double ratio)
+    template<typename T1, typename T2>
+    inline double Interpolate(const T1& p1, const T1& p2, const T2& ratio)
     {
         // Safety check ratio
-        double real_ratio = ratio;
+        T2 real_ratio = ratio;
         if (real_ratio < 0.0)
         {
             real_ratio = 0.0;

--- a/include/arc_utilities/eigen_helpers.hpp
+++ b/include/arc_utilities/eigen_helpers.hpp
@@ -1128,6 +1128,52 @@ namespace EigenHelpers
     }
 
     ////////////////////////////////////////////////////////////////////////////
+    // Math functions on std::pair types
+    ////////////////////////////////////////////////////////////////////////////
+
+    template <typename First, typename Second>
+    inline std::pair<First, Second> Abs(const std::pair<First, Second>& pair)
+    {
+        return {std::abs(pair.first), std::abs(pair.second)};
+    }
+
+    template <typename First, typename Second, typename Scalar>
+    inline std::pair<First, Second> Multiply(const std::pair<First, Second>& pair, const Scalar scalar)
+    {
+        return {pair.first * scalar, pair.second * scalar};
+    }
+
+    template <typename First, typename Second>
+    inline std::pair<First, Second> Multiply(const std::pair<First, Second>& pair1, const std::pair<First, Second>& pair2)
+    {
+        return {pair1.first * pair2.first, pair1.second * pair2.second};
+    }
+
+    template <typename First, typename Second, typename Scalar>
+    inline std::pair<First, Second> Divide(const std::pair<First, Second>& pair, const Scalar scalar)
+    {
+        return {pair.first / scalar, pair.second / scalar};
+    }
+
+    template <typename First, typename Second>
+    inline std::pair<First, Second> Divide(const std::pair<First, Second>& pair1, const std::pair<First, Second>& pair2)
+    {
+        return {pair1.first / pair2.first, pair1.second / pair2.second};
+    }
+
+    template <typename First, typename Second>
+    inline std::pair<First, Second> Add(const std::pair<First, Second>& pair1, const std::pair<First, Second>& pair2)
+    {
+        return {pair1.first + pair2.first, pair1.second + pair2.second};
+    }
+
+    template <typename First, typename Second>
+    inline std::pair<First, Second> Sub(const std::pair<First, Second>& pair1, const std::pair<First, Second>& pair2)
+    {
+        return {pair1.first - pair2.first, pair1.second - pair2.second};
+    }
+
+    ////////////////////////////////////////////////////////////////////////////
     // Math functions on std::vector types
     ////////////////////////////////////////////////////////////////////////////
 


### PR DESCRIPTION
If anyone knows of a good way to do these with operators instead of direction functions, I'm all ears.

The following
```C++
    template<typename ColorType>
    inline ColorType operator*(const ColorType& color, const float factor);
```
does not work (causes the compiler problems when Eigen is included) due to the fact that this function signature could match *any* type whatsoever, not just those that have (r, g, b, a) members.