### PR TITLE
Added travis integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,20 @@
+sudo: required
+
+services:
+  - docker
+
+env: SH="docker exec -t ubuntu-test bash -c"
+    
+before_install:
+  - docker build -t ubuntu ./docker
+  - docker run --name "ubuntu-test" -d -v $(pwd):/root/catkin_ws/src/arc_utilities -w /root/catkin_ws ubuntu tail -f /dev/null
+  - docker ps
+
+install:
+  - $SH "./src/arc_utilities/docker/setup.sh"
+
+script:
+  - $SH "./src/arc_utilities/docker/test.sh"
+
+after_script:
+  - docker images

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -163,11 +163,13 @@ target_link_libraries(test_thin_plate_spline ${PROJECT_NAME} ${catkin_LIBRARIES}
 # To build tests, install google's testing framework
 # https://github.com/google/googletest/
 
-IF(GTEST_FOUND)
-    include_directories(system ${GTEST_INCLUDE_DIRS})
-    add_executable(test_timings tests/timings_tests)
-    target_link_libraries(test_timings ${PROJECT_NAME} ${GTEST_LIBRARIES})
-ENDIF(GTEST_FOUND)
+
+#############
+##  Tests  ##
+#############
+
+catkin_add_gtest(test_timings tests/timings_tests)
+target_link_libraries(test_timings ${PROJECT_NAME})
 
 #############
 ## Install ##

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,11 @@
+FROM ros:kinetic-ros-base
+
+RUN mkdir -p ~/catkin_ws/src
+
+RUN apt update -yq\
+    && apt -yqq install \
+    libeigen3-dev \
+    libz-dev \
+    libpcl-dev \
+    && rm -rf /var/lib/apt/lists/*
+

--- a/docker/setup.sh
+++ b/docker/setup.sh
@@ -1,0 +1,6 @@
+#/bin/bash
+
+. /opt/ros/kinetic/setup.bash
+
+cd ~/catkin_ws
+catkin_make_isolated

--- a/docker/test.sh
+++ b/docker/test.sh
@@ -1,0 +1,7 @@
+#/bin/bash
+
+. /opt/ros/kinetic/setup.bash
+. /root/catkin_ws/devel_isolated/setup.bash
+
+cd ~/catkin_ws
+catkin_make_isolated --catkin-make-args run_tests && catkin_test_results


### PR DESCRIPTION
Travis web page: https://travis-ci.com/UM-ARM-Lab/arc_utilities
(I'm curious if other UM-ARM-Lab github users have access automatically)

I'll add the travis link+image to the readme after this is merged in. Note the build on master is currently "failing" because there is no travis integration on master.
[![Build Status](https://travis-ci.com/UM-ARM-Lab/arc_utilities.svg?branch=master)](https://travis-ci.com/UM-ARM-Lab/arc_utilities)