### PR TITLE
Fix tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -145,11 +145,6 @@ add_executable(test_distance_functions src/test_distance_functions.cpp)
 add_dependencies(test_distance_functions ${catkin_EXPORTED_TARGETS})
 target_link_libraries(test_distance_functions ${PROJECT_NAME} ${catkin_LIBRARIES})
 
-# Simple test Eigen (de)Serialization functions
-add_executable(test_eigen_serialization src/test_eigen_serialization.cpp)
-add_dependencies(test_eigen_serialization ${catkin_EXPORTED_TARGETS})
-target_link_libraries(test_eigen_serialization ${PROJECT_NAME} ${catkin_LIBRARIES})
-
 # Simple test ROS (de)Serialization functions
 add_executable(test_ros_serialization src/test_ros_serialization.cpp)
 add_dependencies(test_ros_serialization ${catkin_EXPORTED_TARGETS})
@@ -168,8 +163,11 @@ target_link_libraries(test_thin_plate_spline ${PROJECT_NAME} ${catkin_LIBRARIES}
 ##  Tests  ##
 #############
 
-catkin_add_gtest(test_timings tests/timings_tests)
+catkin_add_gtest(test_timings tests/timings_tests.cpp)
 target_link_libraries(test_timings ${PROJECT_NAME})
+
+catkin_add_gtest(test_eigen_serialization tests/test_eigen_serialization.cpp)
+target_link_libraries(test_eigen_serialization ${PROJECT_NAME})
 
 #############
 ## Install ##

--- a/tests/test_eigen_serialization.cpp
+++ b/tests/test_eigen_serialization.cpp
@@ -1,5 +1,5 @@
 #include "arc_utilities/serialization_eigen.hpp"
-#include "arc_utilities/arc_helpers.hpp"
+#include <gtest/gtest.h>
 
 template<typename Scalar, int _Rows>
 void testFloatVectors(const size_t num_tests, const ssize_t rows = -1)
@@ -11,7 +11,7 @@ void testFloatVectors(const size_t num_tests, const ssize_t rows = -1)
         EigenType vec;
         if (_Rows == Eigen::Dynamic)
         {
-            assert(rows > 0);
+            ASSERT_GT(rows, 0) << "Dynamically sized vector must have positive number of rows";
             vec.resize(rows);
         }
 
@@ -20,13 +20,11 @@ void testFloatVectors(const size_t num_tests, const ssize_t rows = -1)
         // First, serialize
         std::vector<uint8_t> buffer;
         const size_t bytes_used = arc_utilities::SerializeEigen(vec, buffer);
-        UNUSED(bytes_used);
 
         // Then deserialze and compare
         const auto deserialized = arc_utilities::DeserializeEigen<EigenType>(buffer, 0);
-        UNUSED(deserialized);
-        assert(deserialized.second == bytes_used);
-        assert(deserialized.first == vec);
+        EXPECT_EQ(deserialized.second, bytes_used) << "Deserialized bytes does not match original bytes";
+        EXPECT_EQ(deserialized.first, vec) << "Deserialized value does not match original";
     }
 }
 
@@ -40,7 +38,7 @@ void testFloatMatrices(const size_t num_tests, const ssize_t rows = -1, const ss
         EigenType matrix;
         if (_Rows == Eigen::Dynamic || _Cols == Eigen::Dynamic)
         {
-            assert(rows > 0 && cols > 0);
+            ASSERT_GT(rows, 0) << "Dynamically sized matrix must have positive number of rows";
             matrix.resize(rows, cols);
         }
 
@@ -49,32 +47,31 @@ void testFloatMatrices(const size_t num_tests, const ssize_t rows = -1, const ss
         // First, serialize
         std::vector<uint8_t> buffer;
         const size_t bytes_used = arc_utilities::SerializeEigen(matrix, buffer);
-        UNUSED(bytes_used);
 
         // Then deserialze and compare
         const auto deserialized = arc_utilities::DeserializeEigen<EigenType>(buffer, 0);
-        UNUSED(deserialized);
-        assert(deserialized.second == bytes_used);
-        assert(deserialized.first == matrix);
+        EXPECT_EQ(deserialized.second, bytes_used) << "Deserialized bytes does not match original bytes";
+        EXPECT_EQ(deserialized.first, matrix) << "Deserialized value does not match original";
     }
 }
 
-int main(int argc, char* argv[])
+TEST(EigenSerialization, Vectors_have_same_value_after_serialize_and_deserialize)
 {
-    (void)argc;
-    (void)argv;
-
-    // Note that deserialization functions are only written for some size of matrices, and mostly only for doubles
     testFloatVectors<double, 3>(10);
     testFloatVectors<double, 6>(10);
     testFloatVectors<double, 7>(10);
     testFloatVectors<double, Eigen::Dynamic>(10, 20);
+}
 
+TEST(EigenSerialization, Matrices_have_same_value_after_serialize_and_deserialize)
+{
     testFloatMatrices<double, Eigen::Dynamic, Eigen::Dynamic>(10, 40, 50);
     testFloatMatrices<double, 3, Eigen::Dynamic>(10, 3, 50);
     testFloatMatrices<float, 3, Eigen::Dynamic>(10, 3, 50);
-
-    std::cout << "All tests passed" << std::endl;
-
-    return EXIT_SUCCESS;
 }
+
+GTEST_API_ int main(int argc, char **argv) {
+    testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}
+


### PR DESCRIPTION
Clean up timer tests, including fixing an error
Move test_eigen_serialization to the gtest framework. This avoid the need for UNUSED that @a-price encountered.