### PR TITLE
Profiler fix

### DIFF
--- a/include/arc_utilities/timing.hpp
+++ b/include/arc_utilities/timing.hpp
@@ -66,6 +66,9 @@
 #define PROFILE_PRINT_SUMMARY_FOR_GROUP(names) \
     ::arc_utilities::Profiler::printGroupSummary(names)
 
+#define PROFILE_PRINT_SUMMARY_FOR_ALL()                \
+    ::arc_utilities::Profiler::printAllSummary()
+
 #define PROFILE_WRITE_SUMMARY_FOR_GROUP(filename, names)                 \
     ::arc_utilities::Profiler::writeGroupSummary(filename, names)
 
@@ -148,6 +151,8 @@ namespace arc_utilities
         
         static void printGroupSummary(const std::vector<std::string> &names);
 
+        static void printAllSummary();
+
         static void writeAllSummary(const std::string &filename);
         
         static void writeGroupSummary(const std::string &filename,
@@ -158,6 +163,7 @@ namespace arc_utilities
 
     protected:
         bool isTimerStarted(std::string timer_name);
+        static std::vector<std::string> getAllNames();
 
     protected:
         std::map<std::string, std::vector<TimedDouble> > timed_double_data;

--- a/src/arc_utilities/timing.cpp
+++ b/src/arc_utilities/timing.cpp
@@ -85,8 +85,6 @@ bool Profiler::isTimerStarted(std::string timer_name)
     Profiler* m = getInstance();
     if (m->timers.find(timer_name) == m->timers.end())
     {
-        std::cout << "Attempting to record timer \""<< timer_name <<
-            "\" before timer started\n";
         return false;
     }
     return true;
@@ -105,9 +103,12 @@ double Profiler::record(std::string timer_name)
 double Profiler::recordDouble(std::string timer_name, double datum)
 {
     Profiler* m = getInstance();
-    assert(m->isTimerStarted(timer_name)); //too harsh?
 
-    double time_elapsed = m->timers[timer_name]();
+    double time_elapsed = 0;
+    if(m->isTimerStarted(timer_name))
+    {
+        time_elapsed = m->timers[timer_name]();
+    }
 
     if (m->timed_double_data.find(timer_name) == m->timed_double_data.end())
     {
@@ -208,8 +209,7 @@ void Profiler::printGroupSummary(const std::vector<std::string> &names)
     }
 }
 
-
-void Profiler::writeAllSummary(const std::string &filename)
+std::vector<std::string> Profiler::getAllNames()
 {
     std::vector<std::string> all_names;
     Profiler* m = getInstance();
@@ -226,8 +226,17 @@ void Profiler::writeAllSummary(const std::string &filename)
     }
 
     std::sort(all_names.begin(), all_names.end());
+    return all_names;
+}
 
-    writeGroupSummary(filename, all_names);
+void Profiler::printAllSummary()
+{
+    printGroupSummary(getAllNames());
+}
+
+void Profiler::writeAllSummary(const std::string &filename)
+{
+    writeGroupSummary(filename, getAllNames());
 }
 
 

--- a/tests/timings_tests.cpp
+++ b/tests/timings_tests.cpp
@@ -107,6 +107,7 @@ TEST(TimerTest, Printing_to_screen_runs_without_error)
     // Uncomment this for viewing output.
     // Commented as to not pollute the testing output
     // PROFILE_PRINT_SUMMARY_FOR_GROUP(names); 
+    // TODO: Automate validation of summary text
 }
 
 
@@ -123,6 +124,9 @@ TEST(TimerTest, Writing_summary_to_file_runs_without_error)
     PROFILE_RECORD_DOUBLE("double values", 3.2);
     PROFILE_RECORD_DOUBLE("double values", -1.966);
 
+    PROFILE_RECORD_DOUBLE("unstarted double", 1.2345);
+
+    //TODO: Automate validation of summary text
     PROFILE_WRITE_SUMMARY_FOR_ALL("testing_output.txt");
 }
 
@@ -141,7 +145,9 @@ TEST(TimerTest, Writing_all_to_file_runs_without_error)
     PROFILE_RECORD_DOUBLE("double values", 2.2);
     PROFILE_RECORD_DOUBLE("double values", 3.3);
     PROFILE_RECORD_DOUBLE("double values", 4.4);
-            PROFILE_RECORD_DOUBLE("double values", 5.5);
+    PROFILE_RECORD_DOUBLE("double values", 5.5);
+
+    //TODO: Automate validation of summary text
     PROFILE_WRITE_ALL("testing_output_full.txt");
     PROFILE_WRITE_ALL_FEWER_THAN("testing_output_limited.txt", 3);
 }


### PR DESCRIPTION
Profiler no longer `assert(false)` when recording a double before starting timer.

Added a few other helper functions.

These changes are actually from: https://github.com/UM-ARM-Lab/arc_utilities/pull/68.
This PR handles the merge, since other PRs have caused conflicts