### PR TITLE
Python API for easily initializing roscpp

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,7 @@ project(arc_utilities)
 ## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)
 ## is used, also find other catkin packages
 find_package(catkin REQUIRED COMPONENTS roscpp rospy std_msgs sensor_msgs geometry_msgs)
+find_package(catkin COMPONENTS pybind11_catkin rosconsole)
 
 ## System dependencies are found with CMake's conventions
 find_package(cmake_modules REQUIRED)
@@ -112,6 +113,12 @@ add_library(${PROJECT_NAME}
     )
 add_dependencies(${PROJECT_NAME} ${catkin_EXPORTED_TARGETS})
 target_link_libraries(${PROJECT_NAME} ${catkin_LIBRARIES} z)
+
+if(pybind11_catkin_FOUND)
+    pybind_add_module(roscpp_initializer src/roscpp_initializer.cpp)
+    target_include_directories(roscpp_initializer SYSTEM PUBLIC ${catkin_INCLUDE_DIRS})
+    target_link_libraries(roscpp_initializer PUBLIC ${catkin_LIBRARIES})
+endif()
 
 ###########
 ## Tests ##

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,8 +4,8 @@ project(arc_utilities)
 ## Find catkin macros and libraries
 ## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)
 ## is used, also find other catkin packages
-find_package(catkin REQUIRED COMPONENTS roscpp rospy std_msgs sensor_msgs geometry_msgs)
-find_package(catkin COMPONENTS pybind11_catkin rosconsole)
+find_package(catkin REQUIRED COMPONENTS roscpp rospy std_msgs sensor_msgs geometry_msgs
+    OPTIONAL_COMPONENTS pybind11_catkin rosconsole)
 
 ## System dependencies are found with CMake's conventions
 find_package(cmake_modules REQUIRED)

--- a/package.xml
+++ b/package.xml
@@ -11,6 +11,8 @@
   <build_depend>roscpp</build_depend>
   <build_depend>rospy</build_depend>
   <build_depend>std_msgs</build_depend>
+  <build_depend>rosconsole</build_depend>
+  <build_depend>pybind11_catkin</build_depend>
   <build_depend>sensor_msgs</build_depend>
   <build_depend>geometry_msgs</build_depend>
   <build_depend>eigen</build_depend>

--- a/src/arc_utilities/ros_init.py
+++ b/src/arc_utilities/ros_init.py
@@ -1,0 +1,16 @@
+import roscpp_initializer
+
+import rospy
+
+
+def rospy_and_cpp_init(name):
+    """ Use this function any time you want to call into C++ ROS code.
+      You can use this in place of the moveit roscpp_initializer, and """
+    roscpp_initializer.init_node("cpp_" + name, [], disable_signals=True)
+    rospy.init_node(name)
+
+
+def shutdown():
+    """ ensures the C++ node handle is shut down cleanly. It's good to call this a the end of any program
+      where you called rospy_and_cpp_init """
+    roscpp_initializer.shutdown()

--- a/src/roscpp_initializer.cpp
+++ b/src/roscpp_initializer.cpp
@@ -1,0 +1,96 @@
+#include <vector>
+#include <algorithm>
+#include <string>
+#include <pybind11/pybind11.h>
+#include <pybind11/stl_bind.h>
+#include <pybind11/stl.h>
+#include <ros/console.h>
+#include <ros/spinner.h>
+#include <ros/ros.h>
+#include <memory>
+
+namespace py = pybind11;
+
+std::unique_ptr<ros::AsyncSpinner> spinner;
+
+void init_node(std::string const &name,
+               std::vector<std::string> argv = {},
+               int const rospy_log_level = 2,
+               bool anonymous = false,
+               bool disable_rosout = false,
+               bool disable_signals = false)
+{
+  switch (rospy_log_level)
+  {
+    case 0:
+      ros::console::set_logger_level(name, ros::console::Level::Debug);
+      break;
+    case 1:
+      ros::console::set_logger_level(name, ros::console::Level::Info);
+      break;
+    case 2:
+      ros::console::set_logger_level(name, ros::console::Level::Warn);
+      break;
+    case 3:
+      ros::console::set_logger_level(name, ros::console::Level::Error);
+      break;
+    case 4:
+      ros::console::set_logger_level(name, ros::console::Level::Fatal);
+      break;
+    default:
+      throw std::invalid_argument("log level must be 0-4");
+  }
+
+  using InitOptionUnderlyingType = std::underlying_type_t<ros::init_options::InitOption>;
+  InitOptionUnderlyingType options = {0};
+  if (anonymous)
+  {
+    options |= static_cast<InitOptionUnderlyingType>(ros::init_options::AnonymousName);
+  }
+  if (disable_signals)
+  {
+    options |= static_cast<InitOptionUnderlyingType>(ros::init_options::NoSigintHandler);
+  }
+  if (disable_rosout)
+  {
+    options |= static_cast<InitOptionUnderlyingType>(ros::init_options::NoRosout);
+  }
+  auto argc = static_cast<int>(argv.size());
+  std::vector<char *> argv_pointers;
+  auto const convert = [](const std::string &s)
+  {
+    char *pc = new char[s.size() + 1];
+    std::strcpy(pc, s.c_str());
+    return pc;
+  };
+  std::transform(argv.begin(), argv.end(), std::back_inserter(argv_pointers), convert);
+  ros::init(argc, argv_pointers.data(), name);
+
+  spinner = std::make_unique<ros::AsyncSpinner>(1);
+  spinner->start();
+}
+
+void shutdown()
+{
+    ros::shutdown();
+}
+
+
+PYBIND11_MODULE(roscpp_initializer, m)
+{
+  m.doc() = "roscpp initializer module";
+  m.def("init_node",
+        &init_node,
+        "init node but for C++",
+        py::arg("name"),
+        py::arg("argv") = std::vector<std::string>{},
+        py::arg("log_level") = 2,
+        py::arg("anonymous") = false,
+        py::arg("disable_rosout") = false,
+        py::arg("disable_signals") = false
+  );
+  m.def("shutdown",
+        &shutdown,
+        "shutdown"
+  );
+}

--- a/tests/ros_init_tests.py
+++ b/tests/ros_init_tests.py
@@ -1,0 +1,34 @@
+#! /usr/bin/env python
+import time
+import unittest
+
+import rosnode
+import rospy
+from arc_utilities import ros_init
+
+
+class TestRosInit(unittest.TestCase):
+
+    def test_ros_init(self):
+        name = "test_node_name_" + str(int(time.time()))
+
+        names = rosnode.get_node_names()
+        self.assertNotIn("/" + name, names)
+
+        ros_init.rospy_and_cpp_init(name)
+        rospy.sleep(1)
+
+        names = rosnode.get_node_names()
+        self.assertIn("/" + name, names)
+        self.assertIn("/cpp_" + name, names)
+
+        ros_init.shutdown()
+
+        rospy.sleep(1)
+        # this will still exist, shutdown only shut's down the internal C++ node
+        # WRONG --> self.assertNotIn("/" + name, rosnode.get_node_names())
+        self.assertNotIn("/cpp_" + name, rosnode.get_node_names())
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Any time you call C++ bindings which uses NodeHandle, you need to call the roscpp init first. The preferred API for doing this is to make python bindings to roscpp init. Moveit has a binding for this, but we should have our own, specifically for usage with arm_robots

Better naming than the moveit one, and easier API.