### PR TITLE
drop kinetic testing, add noetic

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,11 +5,11 @@ services:
 
 env:
   matrix:
-  - ROS_VERSION=kinetic BUILD_TYPE=Debug
-  - ROS_VERSION=kinetic BUILD_TYPE=Release
   - ROS_VERSION=melodic BUILD_TYPE=Debug
   - ROS_VERSION=melodic BUILD_TYPE=Release
-    
+  - ROS_VERSION=noetic BUILD_TYPE=Debug
+  - ROS_VERSION=noetic BUILD_TYPE=Release
+
 before_install:
   - docker build -t ubuntu --build-arg ROS_VERSION=$ROS_VERSION ./docker
   - docker run --name "ubuntu-test" -d -v $(pwd):/root/catkin_ws/src/arc_utilities -w /root/catkin_ws ubuntu tail -f /dev/null


### PR DESCRIPTION
I want to use C++ 17 which isn't supported in our kinetic docker image. If someone really wants to use kinetic they can, they just need a more up to date version of gcc to build, which is easy to get even on Ubuntu 16