### PR TITLE
Fix incorrect namespaces and missing imports

### DIFF
--- a/include/arc_utilities/moveit_pose_type.hpp
+++ b/include/arc_utilities/moveit_pose_type.hpp
@@ -6,6 +6,7 @@
 
 #include <moveit/version.h>
 #include <Eigen/Geometry>
+#include <vector>
 
 #define MOVEIT_VERSION_AT_LEAST(x, y, z) \
   (MOVEIT_VERSION_MAJOR > x ||           \

--- a/include/arc_utilities/ostream_operators.hpp
+++ b/include/arc_utilities/ostream_operators.hpp
@@ -2,6 +2,7 @@
 
 #include <ostream>
 #include <typeinfo>
+#include <vector>
 
 template <typename T>
 static std::ostream &operator<<(std::ostream &out, std::vector<T> const &vec) {

--- a/include/arc_utilities/simple_kmeans_clustering.hpp
+++ b/include/arc_utilities/simple_kmeans_clustering.hpp
@@ -5,6 +5,7 @@
 #include <chrono>
 #include <functional>
 #include <iostream>
+#include <map>
 #include <random>
 #include <sstream>
 #include <stdexcept>

--- a/include/arc_utilities/simple_linked_robot_model.hpp
+++ b/include/arc_utilities/simple_linked_robot_model.hpp
@@ -5,6 +5,7 @@
 #include <arc_utilities/eigen_typedefs.hpp>
 #include <arc_utilities/math_helpers.hpp>
 #include <arc_utilities/pretty_print.hpp>
+#include <arc_utilities/serialization.hpp>
 #include <arc_utilities/simple_robot_model_interface.hpp>
 #include <map>
 #include <random>
@@ -57,10 +58,10 @@ class SimpleJointModel {
 
   inline uint64_t SerializeSelf(std::vector<uint8_t>& buffer) const {
     const uint64_t start_buffer_size = buffer.size();
-    arc_helpers::SerializeFixedSizePOD<double>(limits_.first, buffer);
-    arc_helpers::SerializeFixedSizePOD<double>(limits_.second, buffer);
-    arc_helpers::SerializeFixedSizePOD<double>(value_, buffer);
-    arc_helpers::SerializeFixedSizePOD<uint32_t>((uint32_t)type_, buffer);
+    arc_utilities::SerializeFixedSizePOD<double>(limits_.first, buffer);
+    arc_utilities::SerializeFixedSizePOD<double>(limits_.second, buffer);
+    arc_utilities::SerializeFixedSizePOD<double>(value_, buffer);
+    arc_utilities::SerializeFixedSizePOD<uint32_t>((uint32_t)type_, buffer);
     // Figure out how many bytes were written
     const uint64_t end_buffer_size = buffer.size();
     const uint64_t bytes_written = end_buffer_size - start_buffer_size;
@@ -70,19 +71,19 @@ class SimpleJointModel {
   inline uint64_t DeserializeSelf(const std::vector<uint8_t>& buffer, const uint64_t current) {
     uint64_t current_position = current;
     const std::pair<double, uint64_t> deserialized_limits_first =
-        arc_helpers::DeserializeFixedSizePOD<double>(buffer, current_position);
+        arc_utilities::DeserializeFixedSizePOD<double>(buffer, current_position);
     limits_.first = deserialized_limits_first.first;
     current_position += deserialized_limits_first.second;
     const std::pair<double, uint64_t> deserialized_limits_second =
-        arc_helpers::DeserializeFixedSizePOD<double>(buffer, current_position);
+        arc_utilities::DeserializeFixedSizePOD<double>(buffer, current_position);
     limits_.second = deserialized_limits_second.first;
     current_position += deserialized_limits_second.second;
     const std::pair<double, uint64_t> deserialized_value =
-        arc_helpers::DeserializeFixedSizePOD<double>(buffer, current_position);
+        arc_utilities::DeserializeFixedSizePOD<double>(buffer, current_position);
     value_ = deserialized_value.first;
     current_position += deserialized_value.second;
     const std::pair<uint32_t, uint64_t> deserialized_type =
-        arc_helpers::DeserializeFixedSizePOD<uint32_t>(buffer, current_position);
+        arc_utilities::DeserializeFixedSizePOD<uint32_t>(buffer, current_position);
     type_ = (JOINT_TYPE)deserialized_type.first;
     current_position += deserialized_type.second;
     // Figure out how many bytes were read
@@ -223,12 +224,12 @@ class SimpleLinkedConfigSerializer {
   static inline std::string TypeName() { return std::string("SimpleLinkedConfigurationSerializer"); }
 
   static inline uint64_t Serialize(const std::vector<SimpleJointModel>& value, std::vector<uint8_t>& buffer) {
-    return arc_helpers::SerializeVector<SimpleJointModel>(value, buffer, SimpleJointModel::Serialize);
+    return arc_utilities::SerializeVector<SimpleJointModel>(value, buffer, SimpleJointModel::Serialize);
   }
 
   static inline std::pair<std::vector<SimpleJointModel>, uint64_t> Deserialize(const std::vector<uint8_t>& buffer,
                                                                                const uint64_t current) {
-    return arc_helpers::DeserializeVector<SimpleJointModel>(buffer, current, SimpleJointModel::Deserialize);
+    return arc_utilities::DeserializeVector<SimpleJointModel>(buffer, current, SimpleJointModel::Deserialize);
   }
 };
 

--- a/include/arc_utilities/stl_wrappers.hpp
+++ b/include/arc_utilities/stl_wrappers.hpp
@@ -2,6 +2,7 @@
 #define ARC_STL_WRAPPERS
 
 #include <algorithm>
+#include <vector>
 
 namespace arc_std {
 


### PR DESCRIPTION
Errors were highlighted by clion.

Note: There are still a bunch of implicit type casts