### PR TITLE
reduce timeout and import msgs so users don't get confusing error

### DIFF
--- a/src/arc_utilities/tf2wrapper.py
+++ b/src/arc_utilities/tf2wrapper.py
@@ -5,6 +5,8 @@ import rospy
 import tf2_ros
 from arc_utilities import transformation_helper
 from geometry_msgs.msg import Pose
+# noinspection PyUnresolvedReferences
+import tf2_geometry_msgs
 
 
 class TF2Wrapper:
@@ -51,7 +53,7 @@ class TF2Wrapper:
                           parent,
                           child,
                           verbose=True,
-                          spin_delay=rospy.Duration(secs=0, nsecs=500 * 1000 * 1000),
+                          spin_delay=rospy.Duration(secs=0, nsecs=5 * 1000 * 1000),
                           time=rospy.Time()):
         while not self.tf_buffer.can_transform(target_frame=parent, source_frame=child,
                                                time=time, timeout=spin_delay):


### PR DESCRIPTION
The package `tf2_geometry_msgs` must be imported before you can use `transform_to_frame` but previous the user would get a weird error if they passed a `*Stamped` message without importing. This fixes that. the `# noinsepction` makes pycharm shut up about the "unused" import.