### PR TITLE
a more reliable version of TF2Wrapper

### DIFF
--- a/src/arc_utilities/catches.py
+++ b/src/arc_utilities/catches.py
@@ -1,0 +1,65 @@
+import signal
+from typing import Callable, Optional
+
+
+def catch_timeout(seconds: int, func: Callable, *args, **kwargs):
+    def _handle_timeout(signum, frame):
+        raise TimeoutError()
+
+    try:
+        signal.signal(signal.SIGALRM, _handle_timeout)
+        signal.alarm(seconds)
+        try:
+            result = func(*args, **kwargs)
+            return result, False
+        finally:
+            signal.alarm(0)
+    except TimeoutError:
+        print("Caught timeout!")
+        return None, True
+
+
+def retry_on_timeout(t: int, on_timeout: Optional[Callable], f: Callable, *args, **kwargs):
+    """
+    For generators
+    Args:
+        t: timeout in seconds
+        f: a generator, any function with `yield` or `field from`
+        on_timeout: callback used when timeouts happen
+
+    Returns:
+
+    """
+    it = f(*args, **kwargs)
+    while True:
+        try:
+            i, timed_out = catch_timeout(t, next, it)
+            if timed_out:
+                it = f(*args, **kwargs)  # reset the generator
+                if on_timeout is not None:
+                    on_timeout()
+            else:
+                yield i
+        except StopIteration:
+            return
+
+
+def skip_on_timeout(t: int, on_timeout: Optional[Callable], f: Callable, *args, **kwargs):
+    """
+    For generators
+    Args:
+        t: timeout in seconds
+        f: a generator, any function with `yield` or `field from`
+        on_timeout: callback used when timeouts happen
+
+    Returns:
+
+    """
+    it = f(*args, **kwargs)
+    while True:
+        try:
+            i, timed_out = catch_timeout(t, next, it)
+            if not timed_out:
+                yield i
+        except StopIteration:
+            return

--- a/src/arc_utilities/reliable_tf.py
+++ b/src/arc_utilities/reliable_tf.py
@@ -1,0 +1,111 @@
+from functools import partial
+from threading import Thread, Event
+
+import numpy as np
+
+import ros_numpy
+import rospy
+import tf
+from arc_utilities.tf2wrapper import TF2Wrapper
+from geometry_msgs.msg import Pose
+from rospy import Rate
+
+
+def tfkey(*, parent, child):
+    k = (parent, child)
+    return k
+
+
+def send_transform(exit_event, translation, quaternion, parent, child, is_static):
+    tfw = TF2Wrapper()
+    r = Rate(10)
+    while not exit_event.is_set():
+        tfw.send_transform(translation, quaternion, parent, child, is_static, time=rospy.Time.now())
+        r.sleep()
+
+
+def send_transform_matrix(exit_event, transform, parent, child, is_static):
+    tfw = TF2Wrapper()
+    r = Rate(10)
+    while not exit_event.is_set():
+        tfw.send_transform_matrix(transform, parent, child, is_static, time=rospy.Time.now())
+        r.sleep()
+
+
+def send_transform_from_pose_msg(exit_event, pose, parent, child, is_static):
+    tfw = TF2Wrapper()
+    r = Rate(10)
+    while not exit_event.is_set():
+        tfw.send_transform_from_pose_msg(pose, parent, child, is_static, time=rospy.Time.now())
+        r.sleep()
+
+
+class ReliableTF(TF2Wrapper):
+    """
+    abstracts the process of repeatedly sending transforms, to make it look more like sending transforms is guaranteed.
+    this class is a foot gun, it will probably break if you use it in complicated ways.
+    """
+
+    def __init__(self):
+        super().__init__()
+        self.managed_tfs = {}
+
+    def __del__(self):
+        self.close()
+
+    def close(self):
+        for parent, child in list(self.managed_tfs.keys()):
+            self.stop_send(parent, child)
+
+    def stop_send(self, parent, child):
+        k = tfkey(parent=parent, child=child)
+        if k in self.managed_tfs:
+            thread, exit_event = self.managed_tfs.pop(k)
+            exit_event.set()
+            thread.join()
+
+    def start_send_transform_matrix(self, transform, parent, child, is_static=False):
+        send_transform_partial = partial(send_transform_matrix, transform=transform, parent=parent,
+                                         child=child, is_static=is_static)
+
+        def _is_close_func(received_transform):
+            return np.allclose(transform, received_transform)
+
+        self.start_send(parent, child, _is_close_func, send_transform_partial)
+
+    def start_send_transform_from_pose_msg(self, pose: Pose, parent, child, is_static=False):
+        send_transform_partial = partial(send_transform_from_pose_msg, pose=pose, parent=parent,
+                                         child=child, is_static=is_static)
+
+        def _is_close_func(received_transform):
+            return np.allclose(ros_numpy.numpify(pose), received_transform)
+
+        self.start_send(parent, child, _is_close_func, send_transform_partial)
+
+    def start_send_transform(self, translation, quaternion, parent, child, is_static=False):
+        send_transform_partial = partial(send_transform, translation=translation, quaternion=quaternion, parent=parent,
+                                         child=child, is_static=is_static)
+
+        def _is_close_func(received):
+            received_translation = received[:-1, -1]
+            received_quaternion = tf.transformations.quaternion_from_matrix(received)
+            trans_close = np.allclose(translation, received_translation)
+            rot_close = np.allclose(quaternion, received_quaternion)
+            return trans_close and rot_close
+
+        self.start_send(parent, child, _is_close_func, send_transform_partial)
+
+    def start_send(self, parent, child, is_close_func, send_transform_partial):
+        exit_event = Event()
+
+        k = tfkey(parent=parent, child=child)
+        thread = Thread(target=send_transform_partial, args=(exit_event,))
+        thread.start()
+
+        self.managed_tfs[k] = (thread, exit_event)
+
+        # block until the correct transform is received
+        while True:
+            received_transform = self.get_transform(parent, child, verbose=False)
+            if is_close_func(received_transform):
+                break

--- a/tests/test_class_with_thread.py
+++ b/tests/test_class_with_thread.py
@@ -1,0 +1,32 @@
+from threading import Thread, Event
+from time import sleep
+
+from arc_utilities import ros_init
+
+
+def target(exit_event):
+    while not exit_event.is_set():
+        print("running...")
+        sleep(1.0)
+    print("thread exiting.")
+
+
+class Foo:
+    def __init__(self):
+        self.exit_event = Event()
+        self.thread = Thread(target=target, args=(self.exit_event,))
+        self.thread.start()
+
+    def __del__(self):
+        print("die!")
+        self.exit_event.set()
+
+
+@ros_init.with_ros("test_class_with_thread")
+def main():
+    Foo()
+    print("Program ended...")
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/test_reliable_tf.py
+++ b/tests/test_reliable_tf.py
@@ -1,0 +1,93 @@
+import unittest
+
+import numpy as np
+
+import rospy
+from arc_utilities import ros_init
+from arc_utilities.catches import catch_timeout
+from arc_utilities.reliable_tf import ReliableTF
+from arc_utilities.tf2wrapper import TF2Wrapper
+from geometry_msgs.msg import Pose
+
+
+@ros_init.with_ros("test_reliable_tf")
+def tf_sucks():
+    tf = TF2Wrapper()
+    tf.send_transform([0, 0, 1.], [0, 0, 0, 1.], parent='world', child='a')
+    tf.send_transform([0, 0, 1.], [0, 0, 0, 1], parent='world', child='b')
+
+    def _get():
+        return tf.get_transform(parent='a', child='b')
+
+    a2b, timeout = catch_timeout(1, _get)
+    return timeout
+
+
+def test_multiple_instances():
+    tf_1 = ReliableTF()
+    tf_1.start_send_transform([0, 0, 1.], [0, 0, 0, 1.], parent='world', child='a')
+    tf_1.start_send_transform([0, 1., 1.], [0, 0, 0, 1], parent='world', child='b')
+
+    tf_2 = ReliableTF()
+    tf_2.start_send_transform([0, 2., 1.], [0, 0, 0, 1], parent='world', child='c')
+
+    print(tf_1.get_transform(parent='a', child='b'))
+    print(tf_1.get_transform(parent='a', child='c'))
+
+    # tf_1.close()
+    # tf_2.close()
+
+
+def reliable_tf_rocks():
+    tf = ReliableTF()
+    tf.start_send_transform([0, 0, 1.], [0, 0, 0, 1.], parent='world', child='a')
+    tf.start_send_transform([0, 1., 1.], [0, 0, 0, 1], parent='world', child='b')
+    pose = Pose()
+    pose.position.x = 1
+    pose.orientation.z = 1
+    tf.start_send_transform_from_pose_msg(pose, parent='world', child='c')
+    transform = np.array([
+        [1, 0, 0, 1.],
+        [0, 1, 0, 1.],
+        [0, 0, 1, 1.],
+        [0, 0, 0, 1.],
+    ])
+    tf.start_send_transform_matrix(transform, parent='world', child='d')
+
+    def _get():
+        return tf.get_transform(parent='a', child='b')
+
+    a2b, timeout = catch_timeout(1, _get)
+
+    # tf.close()
+
+    return a2b, timeout
+
+
+@ros_init.with_ros("test_reliable_tf")
+def main():
+    # show that tf doesn't work reliably when you just publish one transform
+    # tf_sucks()
+    reliable_tf_rocks()
+    # test_multiple_instances()
+    # tf = TF2Wrapper()
+
+
+class TestAlgorithms(unittest.TestCase):
+
+    def test_tf_sucks(self):
+        a2b, timeout = tf_sucks()
+        self.assertIsNone(a2b)
+        self.assertTrue(timeout)
+
+    def test_reliable_tf_rocks(self):
+        a2b, timeout = reliable_tf_rocks()
+        self.assertIsNotNone(a2b)
+        np.testing.assert_allclose(a2b, np.array([[1, 0, 0, 0], [0, 1, 0, 1], [0, 0, 1, 0], [0, 0, 0, 1.]]))
+        self.assertFalse(timeout)
+
+
+if __name__ == '__main__':
+    main()
+    # unittest.main()
+    print("Program ended...")

--- a/tests/test_reliable_tf.py
+++ b/tests/test_reliable_tf.py
@@ -25,60 +25,52 @@ def tf_sucks():
 
 def test_multiple_instances():
     tf_1 = ReliableTF()
-    tf_1.start_send_transform([0, 0, 1.], [0, 0, 0, 1.], parent='world', child='a')
-    tf_1.start_send_transform([0, 1., 1.], [0, 0, 0, 1], parent='world', child='b')
+    tf_1.start_send_transform([0, 0, 1.], [0, 0, 0, 1.], parent='world', child='c')
+    tf_1.start_send_transform([0, 1., 1.], [0, 0, 0, 1], parent='world', child='d')
 
     tf_2 = ReliableTF()
-    tf_2.start_send_transform([0, 2., 1.], [0, 0, 0, 1], parent='world', child='c')
+    tf_2.start_send_transform([0, 2., 1.], [0, 0, 0, 1], parent='world', child='e')
 
 
 def changing_transforms():
     expected1 = np.array([[1, 0, 0, 0], [0, 1, 0, 1], [0, 0, 1, 0], [0, 0, 0, 1.]])
     expected2 = np.array([[1, 0, 0, 1], [0, 1, 0, 1], [0, 0, 1, 0], [0, 0, 0, 1.]])
     tf = ReliableTF()
-    tf.start_send_transform_matrix(expected1, parent='world', child='a')
-    get1 = tf.get_transform(parent='world', child='a')
+    tf.start_send_transform_matrix(expected1, parent='world', child='f')
+    get1 = tf.get_transform(parent='world', child='f')
     np.testing.assert_allclose(get1, expected1)
-    tf.start_send_transform_matrix(expected2, parent='world', child='a')
-    get2 = tf.get_transform(parent='world', child='a')
+    tf.start_send_transform_matrix(expected2, parent='world', child='g')
+    get2 = tf.get_transform(parent='world', child='g')
     np.testing.assert_allclose(get2, expected2)
 
 
 def reliable_tf_rocks():
     tf = ReliableTF()
-    tf.start_send_transform([0, 0, 1.], [0, 0, 0, 1.], parent='world', child='a')
-    tf.start_send_transform([0, 1., 1.], [0, 0, 0, 1], parent='world', child='b')
+    tf.start_send_transform([0, 0, 1.], [0, 0, 0, 1.], parent='world', child='h')
+    tf.start_send_transform([0, 1., 1.], [0, 0, 0, 1], parent='world', child='i')
     pose = Pose()
     pose.position.x = 1
     pose.orientation.z = 1
-    tf.start_send_transform_from_pose_msg(pose, parent='world', child='c')
+    tf.start_send_transform_from_pose_msg(pose, parent='world', child='j')
     transform = np.array([
         [1, 0, 0, 1.],
         [0, 1, 0, 1.],
         [0, 0, 1, 1.],
         [0, 0, 0, 1.],
     ])
-    tf.start_send_transform_matrix(transform, parent='world', child='d')
+    tf.start_send_transform_matrix(transform, parent='world', child='k')
 
     def _get():
-        return tf.get_transform(parent='a', child='b')
+        return tf.get_transform(parent='h', child='i')
 
     a2b, timeout = catch_timeout(1, _get)
 
     return a2b, timeout
 
 
-@ros_init.with_ros("test_reliable_tf")
-def main():
-    # show that tf doesn't work reliably when you just publish one transform
-    # tf_sucks()
-    # reliable_tf_rocks()
-    changing_transforms()
-    # test_multiple_instances()
-    # tf = TF2Wrapper()
-
-
 class TestReliableTF(unittest.TestCase):
+    def setUp(self):
+        rospy.init_node("test_reliable_tf")
 
     def test_tf_sucks(self):
         a2b, timeout = tf_sucks()
@@ -96,6 +88,4 @@ class TestReliableTF(unittest.TestCase):
 
 
 if __name__ == '__main__':
-    # main()
-    rospy.init_node("test_reliable_tf")
     unittest.main()

--- a/tests/test_reliable_tf.py
+++ b/tests/test_reliable_tf.py
@@ -20,7 +20,7 @@ def tf_sucks():
         return tf.get_transform(parent='a', child='b')
 
     a2b, timeout = catch_timeout(1, _get)
-    return timeout
+    return a2b, timeout
 
 
 def test_multiple_instances():
@@ -31,11 +31,17 @@ def test_multiple_instances():
     tf_2 = ReliableTF()
     tf_2.start_send_transform([0, 2., 1.], [0, 0, 0, 1], parent='world', child='c')
 
-    print(tf_1.get_transform(parent='a', child='b'))
-    print(tf_1.get_transform(parent='a', child='c'))
 
-    # tf_1.close()
-    # tf_2.close()
+def changing_transforms():
+    expected1 = np.array([[1, 0, 0, 0], [0, 1, 0, 1], [0, 0, 1, 0], [0, 0, 0, 1.]])
+    expected2 = np.array([[1, 0, 0, 1], [0, 1, 0, 1], [0, 0, 1, 0], [0, 0, 0, 1.]])
+    tf = ReliableTF()
+    tf.start_send_transform_matrix(expected1, parent='world', child='a')
+    get1 = tf.get_transform(parent='world', child='a')
+    np.testing.assert_allclose(get1, expected1)
+    tf.start_send_transform_matrix(expected2, parent='world', child='a')
+    get2 = tf.get_transform(parent='world', child='a')
+    np.testing.assert_allclose(get2, expected2)
 
 
 def reliable_tf_rocks():
@@ -59,8 +65,6 @@ def reliable_tf_rocks():
 
     a2b, timeout = catch_timeout(1, _get)
 
-    # tf.close()
-
     return a2b, timeout
 
 
@@ -68,12 +72,13 @@ def reliable_tf_rocks():
 def main():
     # show that tf doesn't work reliably when you just publish one transform
     # tf_sucks()
-    reliable_tf_rocks()
+    # reliable_tf_rocks()
+    changing_transforms()
     # test_multiple_instances()
     # tf = TF2Wrapper()
 
 
-class TestAlgorithms(unittest.TestCase):
+class TestReliableTF(unittest.TestCase):
 
     def test_tf_sucks(self):
         a2b, timeout = tf_sucks()
@@ -86,8 +91,11 @@ class TestAlgorithms(unittest.TestCase):
         np.testing.assert_allclose(a2b, np.array([[1, 0, 0, 0], [0, 1, 0, 1], [0, 0, 1, 0], [0, 0, 0, 1.]]))
         self.assertFalse(timeout)
 
+    def test_changing_transform(self):
+        changing_transforms()
+
 
 if __name__ == '__main__':
-    main()
-    # unittest.main()
-    print("Program ended...")
+    # main()
+    rospy.init_node("test_reliable_tf")
+    unittest.main()


### PR DESCRIPTION
TF is meant to work with constant publishing of all transforms, but sometimes you want to just publish once. Unfortunately, your message is likely to be dropped, or you're likely to get weird error messages about timing issues. This tries to fix this to some extent.

It works by starting a background thread to constantly publish for you, and checks that the transform you publish exists before returning from the "start_end_*" methods